### PR TITLE
Add CityController for city management operations

### DIFF
--- a/Presentation/API/Controller/CityController.cs
+++ b/Presentation/API/Controller/CityController.cs
@@ -1,0 +1,42 @@
+﻿using Application.Features.Cities.Commands.Create;
+using Application.Features.Cities.Dtos;
+using Application.Features.Cities.Queries;
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace FitCircleAPI.Controllers
+{
+    [Route("api/[controller]")]
+    [ApiController]
+    public class CityController : ControllerBase
+    {
+        public readonly IMediator _mediatr;
+
+        public CityController(IMediator mediatr)
+        {
+            _mediatr = mediatr;
+        }
+
+        [HttpPost]
+        [Authorize(Roles = "Admin")]
+        public async Task<IActionResult> Create([FromBody] CreateCityDto dto)
+        {
+            var commandRequest = new CreateCityCommandRequest(dto);
+            var city = await _mediatr.Send(commandRequest);
+            return CreatedAtAction(nameof(Create), city);
+        }
+
+        [HttpGet]
+
+        public async Task<IActionResult> GetAllCities()
+        {
+            var cities = _mediatr.Send(new GetAllCitiesQueryRequest()); 
+            if(cities != null)
+            {
+                return Ok(cities);
+            }
+            return BadRequest();
+        }
+    }
+}


### PR DESCRIPTION
Introduces a new `CityController` in the `FitCircleAPI.Controllers` namespace to handle city-related HTTP requests. Key features include:
- A constructor that initializes an `IMediator` instance for command and query handling.
- A `Create` method for POST requests to create cities, restricted to users with the "Admin" role, returning a `201 Created` response.
- A `GetAllCities` method for GET requests to retrieve all cities, returning the list or a `400 Bad Request` if no cities are found.