### PR TITLE
Add delete city command handler and request class

### DIFF
--- a/Core/Application/Features/Cities/Commands/Delete/DeleteCityCommandHandler.cs
+++ b/Core/Application/Features/Cities/Commands/Delete/DeleteCityCommandHandler.cs
@@ -1,0 +1,27 @@
+﻿using Application.Abstracts.Repositories.Cities;
+using MediatR;
+
+namespace Application.Features.Cities.Commands.Delete
+{
+    public class DeleteCityCommandHandler : IRequestHandler<DeleteCityCommandRequest, bool>
+    {
+        readonly ICityWriteRepository _writeRepository;
+        readonly ICityReadRepository _readRepository;
+
+        public DeleteCityCommandHandler(ICityWriteRepository writeRepository, ICityReadRepository readRepository)
+        {
+            _writeRepository = writeRepository;
+            _readRepository = readRepository;
+        }
+
+        public async Task<bool> Handle(DeleteCityCommandRequest request, CancellationToken cancellationToken)
+        {
+            var city = await _readRepository.GetByIdAsync(request.Id);
+            if(city == null) 
+                return false;
+
+             _writeRepository.Remove(city);
+            return true;
+        }
+    }
+}

--- a/Core/Application/Features/Cities/Commands/Delete/DeleteCityCommandRequest.cs
+++ b/Core/Application/Features/Cities/Commands/Delete/DeleteCityCommandRequest.cs
@@ -1,0 +1,9 @@
+﻿using MediatR;
+
+namespace Application.Features.Cities.Commands.Delete
+{
+    public class DeleteCityCommandRequest : IRequest<bool>
+    {
+        public Guid Id { get; set; }
+    }
+}


### PR DESCRIPTION
Introduces `DeleteCityCommandHandler` to handle delete city commands using MediatR. Implements `IRequestHandler` and utilizes `ICityWriteRepository` and `ICityReadRepository` for city removal and retrieval.

Also adds `DeleteCityCommandRequest` class with an `Id` property to specify the city to be deleted.