### PR TITLE
Add CurrentUserService and PasetoService implementations

### DIFF
--- a/Infrastructure/Infrastructure/Services/CurrentUserService.cs
+++ b/Infrastructure/Infrastructure/Services/CurrentUserService.cs
@@ -1,0 +1,44 @@
+﻿using Application.Common.Interfaces;
+using Microsoft.AspNetCore.Http;
+using System.Security.Claims;
+
+namespace Infrustructure.Services
+{
+    public class CurrentUserService : ICurrentUserService
+    {
+        readonly IHttpContextAccessor _httpContextAccessor;
+
+        public CurrentUserService(IHttpContextAccessor httpContextAccessor)
+        {
+            _httpContextAccessor = httpContextAccessor;
+        }
+
+        private HttpContext httpContext => _httpContextAccessor?.HttpContext;
+        private IHeaderDictionary Headers => httpContext?.Request?.Headers;
+
+        public string GetCurrentUserId() => httpContext?.User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+        public string GetCurrentUsername() =>
+              httpContext?.User.FindFirst(ClaimTypes.Name)?.Value;
+
+        public string GetCurrentUserRole() =>
+        httpContext?.User.FindFirst(ClaimTypes.Role)?.Value;
+
+        public string GetCurrentUserFullName() =>
+            httpContext?.User.FindFirst(ClaimTypes.GivenName)?.Value;
+        public string GetUserAgent() =>
+            Headers?["User-Agent"].ToString();
+
+        public string GetFingerprint() =>
+            Headers?["X-Fingerprint"].ToString();
+
+        public string GetRemoteIpAddress() =>
+            Headers?["X-Real-IP"].FirstOrDefault()?? httpContext?.Connection?.RemoteIpAddress?.ToString();
+
+        public string GetRefreshToken() =>
+            httpContext.Request.Cookies["refresh_token"];
+
+        public string GetAccessToken() =>
+            httpContext.Request.Cookies["access_token"];
+
+    }
+}

--- a/Infrastructure/Infrastructure/Services/PasetoService.cs
+++ b/Infrastructure/Infrastructure/Services/PasetoService.cs
@@ -1,0 +1,68 @@
+﻿using Application.Common.Interfaces;
+using Domain.Models;
+using Paseto;
+using Paseto.Builder;
+using Paseto.Validators;
+using System.Security.Claims;
+
+namespace Infrustructure.Services;
+
+public class PasetoService : IPasetoService
+{
+    readonly PasetoSettings _pasetoSettings;
+
+    public PasetoService(PasetoSettings pasetoSettings)
+    {
+        _pasetoSettings = pasetoSettings;
+    }
+
+    public string GenerateToken(string userCode, string name, string fullName, string userRole)
+    {
+        return new PasetoBuilder()
+            .UseV4(Purpose.Local)
+            .WithKey(Convert.FromBase64String(_pasetoSettings.Secret), Encryption.SymmetricKey)
+            .AddClaim(ClaimTypes.NameIdentifier, userCode)
+            .AddClaim(ClaimTypes.Name, name)
+            .AddClaim(ClaimTypes.GivenName, fullName)
+            .AddClaim(ClaimTypes.Role, userRole)
+            .Issuer(_pasetoSettings.Issuer)
+            .Subject(Guid.NewGuid().ToString())
+            .Audience(_pasetoSettings.Audience)
+            .IssuedAt(DateTime.UtcNow)
+            .Expiration(DateTime.UtcNow.AddMinutes(_pasetoSettings.AccessTokenExpirationMinutes))
+            .TokenIdentifier(Guid.NewGuid().ToString())
+            .AddFooter("env=.;key=v1;type=access")
+            .Encode();
+    }
+
+    public ClaimsPrincipal ValidateToken(string token)
+    {
+        var valParams = new PasetoTokenValidationParameters
+        {
+            ValidateLifetime = true,
+            ValidateAudience = true,
+            ValidateIssuer = true,
+            ValidAudience = _pasetoSettings.Audience,
+            ValidIssuer = _pasetoSettings.Issuer,
+        };
+
+        var payload = new PasetoBuilder()
+        .UseV4(Purpose.Local)
+        .WithKey(Convert.FromBase64String(_pasetoSettings.Secret), Encryption.SymmetricKey)
+        .Decode(token, valParams);
+
+        return payload.IsValid ? CreatePrincipalFromPasetoPayload(payload.Paseto.Payload) : null;
+    }
+
+    private ClaimsPrincipal CreatePrincipalFromPasetoPayload(Dictionary<string, object> payload)
+    {
+        var claims = new List<Claim>();
+
+        foreach (var item in payload)
+            claims.Add(new Claim(item.Key, item.Value.ToString()));
+
+        var identity = new ClaimsIdentity(claims, "Paseto");
+        var pricipal = new ClaimsPrincipal(identity);
+        return pricipal;
+    }
+}


### PR DESCRIPTION
This commit introduces two new service classes:
- `CurrentUserService` implements `ICurrentUserService` to provide methods for retrieving current user information, including user ID, username, role, and tokens, using `IHttpContextAccessor`.
- `PasetoService` implements `IPasetoService` for generating and validating PASETO tokens, handling user claims and token validation parameters.