### PR TITLE
Add generic repository classes for data access

### DIFF
--- a/Infrastructure/Persistance/Repositories/GenericReadRepository.cs
+++ b/Infrastructure/Persistance/Repositories/GenericReadRepository.cs
@@ -1,0 +1,37 @@
+﻿using Application.Abstracts.Repositories;
+using Domain.Common;
+using Microsoft.EntityFrameworkCore;
+using Persistance.Context;
+
+namespace Persistance.Repositories
+{
+    public class GenericReadRepository<T> : IReadRepository<T> where T : BaseAuditableEntity
+    {
+        readonly FitCircleDbContext _context;
+
+        public GenericReadRepository(FitCircleDbContext context)
+        {
+            _context = context;
+        }
+
+        public async Task<IReadOnlyList<T>> GetAllAsync(CancellationToken cancellationToken = default)
+        {
+            return await _context.Set<T>().ToListAsync(cancellationToken);
+        }
+
+        public async Task<T> GetByIdAsync(Guid id, CancellationToken cancellationToken = default)
+        {
+            var entity = await _context.Set<T>().FindAsync([id], cancellationToken).ConfigureAwait(false);
+            if (entity == null)
+            {
+                throw new InvalidOperationException($"Entity of type {typeof(T).Name} with ID {id} was not found.");
+            }
+            return entity;
+        }
+
+        public IQueryable<T> Query()
+        {
+            return _context.Set<T>().AsQueryable();
+        }
+    }
+}

--- a/Infrastructure/Persistance/Repositories/GenericWriteRepository.cs
+++ b/Infrastructure/Persistance/Repositories/GenericWriteRepository.cs
@@ -1,0 +1,47 @@
+﻿using Application.Abstracts.Repositories;
+using Domain.Common;
+using Persistance.Context;
+using System.Threading.Tasks;
+
+namespace Persistance.Repositories
+{
+    public class GenericWriteRepository<T> : IWriteRepository<T> where T : BaseAuditableEntity
+    {
+        readonly FitCircleDbContext _context;
+
+        public GenericWriteRepository(FitCircleDbContext context)
+        {
+            _context = context;
+        }
+
+        public async Task AddAsync(T entity, CancellationToken cancellationToken = default)
+        {
+            await _context.Set<T>().AddAsync(entity, cancellationToken);
+        }
+
+        public async Task AddRangeAsync(IEnumerable<T> entities, CancellationToken cancellationToken = default)
+        {
+            await _context.Set<T>().AddRangeAsync(entities, cancellationToken);
+        }
+
+        public void Update(T entity)
+        {
+            _context.Set<T>().Update(entity);
+        }
+
+        public void Remove(T entity)
+        {
+            _context.Set<T>().Remove(entity);
+        }
+
+        public void RemoveRange(IEnumerable<T> entities)
+        {
+            _context.Set<T>().RemoveRange(entities);
+        }
+
+        public async Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
+        {
+            return await _context.SaveChangesAsync(cancellationToken);
+        }
+    }
+}


### PR DESCRIPTION
Introduces `GenericReadRepository<T>` and `GenericWriteRepository<T>` to implement `IReadRepository<T>` and `IWriteRepository<T>`. These classes facilitate data access and manipulation for entities inheriting from `BaseAuditableEntity`, providing methods for retrieving, adding, updating, and removing entities using `FitCircleDbContext` with support for asynchronous operations.