### PR TITLE
Add ITokenService interface for token management

### DIFF
--- a/Core/Application/Common/ITokenService.cs
+++ b/Core/Application/Common/ITokenService.cs
@@ -1,0 +1,12 @@
+﻿using Domain.Identity;
+using System.Security.Claims;
+
+namespace Application.Common.Interfaces
+{
+    public interface ITokenService
+    {
+        string GenerateAccessToken(ApplicationUser user, IList<string> roles);
+        string GenerateRefreshToken();
+        ClaimsPrincipal? GetPrincipalFromExpiredToken(string token);
+    }
+}


### PR DESCRIPTION
Introduces the `ITokenService` interface in the
`Application.Common.Interfaces` namespace. This interface defines methods for generating access and refresh tokens, as well as retrieving a `ClaimsPrincipal` from an expired token. Necessary using directives for `Domain.Identity` and `System.Security.Claims` are also included.